### PR TITLE
Corrected sd-image.nix import to use .../sd-card/sd-image.nix as per error

### DIFF
--- a/rpi4-image.nix
+++ b/rpi4-image.nix
@@ -1,7 +1,7 @@
 { config, lib, pkgs, ... }: {
   nixpkgs.localSystem.system = "aarch64-linux";
   imports =
-    [ <nixpkgs/nixos/modules/installer/cd-dvd/sd-image.nix> ./base-config.nix ];
+    [ <nixpkgs/nixos/modules/installer/sd-card/sd-image.nix> ./base-config.nix ];
   boot.kernelPackages = pkgs.linuxPackages_rpi4;
   boot.loader.grub.enable = false;
   boot.loader.generic-extlinux-compatible.enable = true;


### PR DESCRIPTION
Hi there,

I get the following warning/trace error when using this build template and wanted to submit a PR to remove the warning for others.

```
λ nix-build '<nixpkgs/nixos>' -A config.system.build.sdImage -I nixos-config=./rpi4-image.nix
trace: warning: .../cd-dvd/sd-image.nix is deprecated and will eventually be removed.
Please switch to .../sd-card/sd-image.nix, instead.
```