### PR TITLE
Workaround for https://github.com/NixOS/nixpkgs/issues/154163

### DIFF
--- a/rpi4-image.nix
+++ b/rpi4-image.nix
@@ -1,7 +1,9 @@
 { config, lib, pkgs, ... }: {
   nixpkgs.localSystem.system = "aarch64-linux";
-  imports =
-    [ <nixpkgs/nixos/modules/installer/sd-card/sd-image.nix> ./base-config.nix ];
+  imports = [
+    <nixpkgs/nixos/modules/installer/sd-card/sd-image.nix>
+    ./base-config.nix
+  ];
   boot.kernelPackages = pkgs.linuxPackages_rpi4;
   boot.loader.grub.enable = false;
   boot.loader.generic-extlinux-compatible.enable = true;
@@ -23,6 +25,15 @@
     "sun4i_drm"
     "sun8i_drm_hdmi"
     "sun8i_mixer"
+  ];
+
+  # Fix missing modules
+  # https://github.com/NixOS/nixpkgs/issues/154163
+  nixpkgs.overlays = [
+    (final: super: {
+      makeModulesClosure = x:
+        super.makeModulesClosure (x // { allowMissing = true; });
+    })
   ];
 
   sdImage = {


### PR DESCRIPTION
Thanks for this template! It is great.

When trying it out, at first the kernel wouldn't build properly...

It was an issue in nixpkgs; I found [this issue](https://github.com/NixOS/nixpkgs/issues/154163) and after trying the workaround, the template now build successfully.

I have included the workaround in this PR and ran the file through `nixfmt`. 